### PR TITLE
fix type of `configurationKey` field of `GetConfiguration.conf`

### DIFF
--- a/src/v16/call_result.rs
+++ b/src/v16/call_result.rs
@@ -28,7 +28,7 @@
 //!```
 
 use super::enums::ParsedGenericStatus;
-use super::data_types::{DateTimeWrapper, IdTagInfo};
+use super::data_types::{DateTimeWrapper, IdTagInfo, KeyValue};
 use alloc::collections::btree_map::BTreeMap;
 use alloc::string::String;
 use alloc::vec::Vec;
@@ -308,7 +308,7 @@ impl Status for GetCompositeSchedule {
 /// This struct might come as empty due to the optional fields.    
 /// This might be ill interpreted by the deserializer.    
 pub struct GetConfiguration {
-    pub configuration_key: Option<Vec<String>>,
+    pub configuration_key: Option<Vec<KeyValue>>,
     pub unknown_key: Option<Vec<String>>,
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -169,14 +169,30 @@ fn test_authorization_call_result() {
 
 #[test]
 fn test_get_configuration_call_result() {
-    let data = "[3, \"253356461\", {\"configurationKey\": [\"key1\", \"key2\"]}]";
+    let data = "[3, \"253356461\", {\"configurationKey\":[
+        {\"key\":\"key1\", \"readonly\": false, \"value\": \"val1\" },
+        {\"key\":\"key2\", \"readonly\": true, \"value\": \"val2\" }
+    ]}]";
     let message = deserialize_to_message(data).unwrap();
     println!("\nParsed: {:?}\n", message);
 
 
     let auth = ocpp_rs::v16::call_result::ResultPayload::PossibleEmptyResponse(
         ocpp_rs::v16::call_result::EmptyResponses::GetConfiguration(
-            ocpp_rs::v16::call_result::GetConfiguration { configuration_key: Some(vec!["key1".to_string(), "key2".to_string()]), unknown_key: None }
+            ocpp_rs::v16::call_result::GetConfiguration {
+                configuration_key: Some(vec![
+                    KeyValue {
+                        key: "key1".to_string(),
+                        readonly: false,
+                        value: Some("val1".to_string()),
+                    },
+                    KeyValue {
+                        key:  "key2".to_string(),
+                        readonly: true,
+                        value: Some("val2".to_string())
+                    }]),
+                unknown_key: None
+            }
         ),
     );
 


### PR DESCRIPTION
`GetConfiguration` result has invalid type of field. According to OCPP 1.6 spec, it must be `KeyValue`.
![image](https://github.com/user-attachments/assets/55f7a512-8c29-4b00-8a8e-736f086aaa77)
