### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,6 @@
 name: Rust
+permissions:
+  contents: read
 
 on: [push, pull_request, merge_group]
 


### PR DESCRIPTION
Potential fix for [https://github.com/angelorodem/ocpp-rs/security/code-scanning/1](https://github.com/angelorodem/ocpp-rs/security/code-scanning/1)

To address the issue, an explicit `permissions` block should be added to the workflow. Since none of the steps require write access to repository contents, the most conservative and recommended permissions are `contents: read`, which prevents the workflow from using `GITHUB_TOKEN` for any write actions on repo contents (commits, pushes, etc.). This block should be placed at the root of the workflow file, immediately after the `name:` and before the `on:` or `jobs:` keys. This ensures that every job in the workflow receives these minimal permissions unless further overridden.

No imports or external dependencies are needed, as this is a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
